### PR TITLE
Add inventory management controllers and routes

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -6,3 +6,19 @@ use CodeIgniter\Router\RouteCollection;
  * @var RouteCollection $routes
  */
 $routes->get('/', 'Home::index');
+
+// Barang routes
+$routes->get('barang', 'BarangController::index');
+$routes->post('barang', 'BarangController::create');
+$routes->put('barang/(:segment)', 'BarangController::update/$1');
+$routes->delete('barang/(:segment)', 'BarangController::delete/$1');
+
+// Supplier routes
+$routes->get('supplier', 'SupplierController::index');
+$routes->post('supplier', 'SupplierController::create');
+$routes->put('supplier/(:segment)', 'SupplierController::update/$1');
+$routes->delete('supplier/(:segment)', 'SupplierController::delete/$1');
+
+// Stock routes
+$routes->get('stok', 'StockController::index');
+$routes->put('stok', 'StockController::update');

--- a/app/Controllers/BarangController.php
+++ b/app/Controllers/BarangController.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Controllers;
+
+use CodeIgniter\Controller;
+use Config\Database;
+use DateTime;
+
+class BarangController extends Controller
+{
+  protected $db;
+
+  public function __construct()
+  {
+    $this->db = Database::connect();
+  }
+
+  /**
+   * GET /barang
+   * Get all items
+   */
+  public function index()
+  {
+    $items = $this->db->table('barang')->get()->getResult();
+
+    return $this->response->setJSON([
+      'success' => true,
+      'data'    => $items,
+    ]);
+  }
+
+  /**
+   * POST /barang
+   * Create item
+   */
+  public function create()
+  {
+    $data = $this->request->getJSON(true);
+
+    $now = (new DateTime())->format('Y-m-d H:i:s');
+
+    $insert = [
+      'kode'       => $data['kode'] ?? null,
+      'nama'       => $data['nama'] ?? null,
+      'kategori'   => $data['kategori'] ?? null,
+      'satuan'     => $data['satuan'] ?? null,
+      'harga'      => $data['harga'] ?? 0,
+      'supplier'   => $data['supplier'] ?? null,
+      'stokMinimal'=> $data['stokMinimal'] ?? 0,
+      'deskripsi'  => $data['deskripsi'] ?? null,
+      'createdAt'  => $now,
+      'updatedAt'  => $now,
+    ];
+
+    $this->db->table('barang')->insert($insert);
+    $id = $this->db->insertID();
+
+    $item = $this->db->table('barang')->where('id', $id)->get()->getRow();
+
+    return $this->response->setJSON([
+      'success' => true,
+      'data'    => $item,
+    ]);
+  }
+
+  /**
+   * PUT /barang/{id}
+   * Update item
+   */
+  public function update($id)
+  {
+    $data = $this->request->getJSON(true);
+
+    $update = [];
+    if (array_key_exists('kode', $data)) $update['kode'] = $data['kode'];
+    if (array_key_exists('nama', $data)) $update['nama'] = $data['nama'];
+    if (array_key_exists('kategori', $data)) $update['kategori'] = $data['kategori'];
+    if (array_key_exists('satuan', $data)) $update['satuan'] = $data['satuan'];
+    if (array_key_exists('harga', $data)) $update['harga'] = $data['harga'];
+    if (array_key_exists('supplier', $data)) $update['supplier'] = $data['supplier'];
+    if (array_key_exists('stokMinimal', $data)) $update['stokMinimal'] = $data['stokMinimal'];
+    if (array_key_exists('deskripsi', $data)) $update['deskripsi'] = $data['deskripsi'];
+
+    $update['updatedAt'] = (new DateTime())->format('Y-m-d H:i:s');
+
+    $this->db->table('barang')->where('id', $id)->update($update);
+
+    $item = $this->db->table('barang')->where('id', $id)->get()->getRow();
+
+    return $this->response->setJSON([
+      'success' => true,
+      'data'    => $item,
+    ]);
+  }
+
+  /**
+   * DELETE /barang/{id}
+   * Delete item
+   */
+  public function delete($id)
+  {
+    $this->db->table('barang')->where('id', $id)->delete();
+
+    return $this->response->setJSON([
+      'success' => true,
+      'message' => 'Item deleted successfully',
+    ]);
+  }
+}

--- a/app/Controllers/StockController.php
+++ b/app/Controllers/StockController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Controllers;
+
+use CodeIgniter\Controller;
+use Config\Database;
+use DateTime;
+
+class StockController extends Controller
+{
+  protected $db;
+
+  public function __construct()
+  {
+    $this->db = Database::connect();
+  }
+
+  /**
+   * GET /stok
+   * Get stock information
+   */
+  public function index()
+  {
+    $barangId = $this->request->getGet('barangId');
+    $builder  = $this->db->table('stok');
+
+    if (!empty($barangId)) {
+      $builder->where('barangId', $barangId);
+    }
+
+    $stocks = $builder->get()->getResult();
+
+    return $this->response->setJSON([
+      'success' => true,
+      'data'    => $stocks,
+    ]);
+  }
+
+  /**
+   * PUT /stok
+   * Update stock
+   */
+  public function update()
+  {
+    $data = $this->request->getJSON(true);
+
+    $barangId = $data['barangId'] ?? null;
+    $quantity = (int) ($data['quantity'] ?? 0);
+    $type     = $data['type'] ?? 'add';
+
+    if (empty($barangId)) {
+      return $this->response->setJSON([
+        'success' => false,
+        'message' => 'barangId is required',
+      ])->setStatusCode(400);
+    }
+
+    $builder = $this->db->table('stok');
+    $stock   = $builder->where('barangId', $barangId)->get()->getRowArray();
+
+    $now = (new DateTime())->format('Y-m-d H:i:s');
+
+    if ($stock) {
+      $currentQuantity = (int) ($stock['quantity'] ?? 0);
+
+      if ($type === 'subtract') {
+        $newQuantity = max(0, $currentQuantity - $quantity);
+      } else {
+        $newQuantity = $currentQuantity + $quantity;
+      }
+
+      $builder->where('barangId', $barangId)->update([
+        'quantity'    => $newQuantity,
+        'lastUpdated' => $now,
+      ]);
+    } else {
+      $newQuantity = $type === 'subtract' ? 0 : max(0, $quantity);
+
+      $builder->insert([
+        'barangId'    => $barangId,
+        'quantity'    => $newQuantity,
+        'lastUpdated' => $now,
+      ]);
+    }
+
+    $updatedStock = $builder->where('barangId', $barangId)->get()->getRow();
+
+    return $this->response->setJSON([
+      'success' => true,
+      'data'    => $updatedStock,
+    ]);
+  }
+}

--- a/app/Controllers/SupplierController.php
+++ b/app/Controllers/SupplierController.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Controllers;
+
+use CodeIgniter\Controller;
+use Config\Database;
+use DateTime;
+
+class SupplierController extends Controller
+{
+  protected $db;
+
+  public function __construct()
+  {
+    $this->db = Database::connect();
+  }
+
+  /**
+   * GET /supplier
+   * Get all suppliers
+   */
+  public function index()
+  {
+    $suppliers = $this->db->table('supplier')->get()->getResult();
+
+    return $this->response->setJSON([
+      'success' => true,
+      'data'    => $suppliers,
+    ]);
+  }
+
+  /**
+   * POST /supplier
+   * Create supplier
+   */
+  public function create()
+  {
+    $data = $this->request->getJSON(true);
+
+    $now = (new DateTime())->format('Y-m-d H:i:s');
+
+    $insert = [
+      'nama'      => $data['nama'] ?? null,
+      'kontak'    => $data['kontak'] ?? null,
+      'alamat'    => $data['alamat'] ?? null,
+      'email'     => $data['email'] ?? null,
+      'telepon'   => $data['telepon'] ?? null,
+      'status'    => 'active',
+      'createdAt' => $now,
+      'updatedAt' => $now,
+    ];
+
+    $this->db->table('supplier')->insert($insert);
+    $id = $this->db->insertID();
+
+    $supplier = $this->db->table('supplier')->where('id', $id)->get()->getRow();
+
+    return $this->response->setJSON([
+      'success' => true,
+      'data'    => $supplier,
+    ]);
+  }
+
+  /**
+   * PUT /supplier/{id}
+   * Update supplier
+   */
+  public function update($id)
+  {
+    $data = $this->request->getJSON(true);
+
+    $update = [];
+    if (array_key_exists('nama', $data)) $update['nama'] = $data['nama'];
+    if (array_key_exists('kontak', $data)) $update['kontak'] = $data['kontak'];
+    if (array_key_exists('alamat', $data)) $update['alamat'] = $data['alamat'];
+    if (array_key_exists('email', $data)) $update['email'] = $data['email'];
+    if (array_key_exists('telepon', $data)) $update['telepon'] = $data['telepon'];
+    if (array_key_exists('status', $data)) $update['status'] = $data['status'];
+
+    $update['updatedAt'] = (new DateTime())->format('Y-m-d H:i:s');
+
+    $this->db->table('supplier')->where('id', $id)->update($update);
+
+    $supplier = $this->db->table('supplier')->where('id', $id)->get()->getRow();
+
+    return $this->response->setJSON([
+      'success' => true,
+      'data'    => $supplier,
+    ]);
+  }
+
+  /**
+   * DELETE /supplier/{id}
+   * Delete supplier
+   */
+  public function delete($id)
+  {
+    $this->db->table('supplier')->where('id', $id)->delete();
+
+    return $this->response->setJSON([
+      'success' => true,
+      'message' => 'Supplier deleted successfully',
+    ]);
+  }
+}


### PR DESCRIPTION
## Summary
- add controllers to manage barang, supplier, and stok data with CRUD-style responses
- register API routes for the new inventory and stock endpoints

## Testing
- composer test (fails: phpunit: not found)


------
https://chatgpt.com/codex/tasks/task_e_68d367eaa56083328707ec1040f32194