### PR TITLE
Standardize API responses with helper

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -6,3 +6,41 @@ use CodeIgniter\Router\RouteCollection;
  * @var RouteCollection $routes
  */
 $routes->get('/', 'Home::index');
+
+// Barang routes
+$routes->get('barang', 'BarangController::index');
+$routes->post('barang', 'BarangController::create');
+$routes->put('barang/(:segment)', 'BarangController::update/$1');
+$routes->delete('barang/(:segment)', 'BarangController::delete/$1');
+
+// Supplier routes
+$routes->get('supplier', 'SupplierController::index');
+$routes->post('supplier', 'SupplierController::create');
+$routes->put('supplier/(:segment)', 'SupplierController::update/$1');
+$routes->delete('supplier/(:segment)', 'SupplierController::delete/$1');
+
+// Stock routes
+$routes->get('stok', 'StockController::index');
+$routes->put('stok', 'StockController::update');
+
+// Permintaan routes
+$routes->get('permintaan', 'PermintaanController::index');
+$routes->post('permintaan', 'PermintaanController::create');
+$routes->put('permintaan/(:segment)', 'PermintaanController::update/$1');
+
+// Pengiriman routes
+$routes->get('pengiriman', 'DeliveryController::index');
+$routes->post('pengiriman', 'DeliveryController::create');
+$routes->put('pengiriman/(:segment)', 'DeliveryController::update/$1');
+
+// Laporan routes
+$routes->get('laporan', 'ReportsController::index');
+$routes->get('laporan/penjualan', 'ReportsController::sales');
+$routes->get('laporan/permintaan', 'ReportsController::requests');
+$routes->get('laporan/pengiriman', 'ReportsController::deliveries');
+$routes->post('laporan', 'ReportsController::create');
+$routes->delete('laporan/(:segment)', 'ReportsController::delete/$1');
+
+// Company settings routes
+$routes->get('company', 'CompanyController::index');
+$routes->put('company', 'CompanyController::update');

--- a/app/Controllers/AuthController.php
+++ b/app/Controllers/AuthController.php
@@ -2,7 +2,6 @@
 
 namespace App\Controllers;
 
-use CodeIgniter\Controller;
 use Config\Database;
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Validation\Constraint\SignedWith;
@@ -10,7 +9,7 @@ use Lcobucci\JWT\Validation\Constraint\ValidAt;
 use Lcobucci\Clock\SystemClock;
 use DateTimeImmutable;
 
-class AuthController extends Controller
+class AuthController extends BaseController
 {
   private $config;
 
@@ -32,10 +31,7 @@ class AuthController extends Controller
     $user = $db->table('users')->where('email', $email)->get()->getRow();
 
     if (!$user || !password_verify($password, $user->password)) {
-      return $this->response->setJSON([
-        'success' => false,
-        'message' => 'Invalid credentials'
-      ]);
+      return respondUnauthorized($this->response, 'Invalid credentials');
     }
 
     $now   = new DateTimeImmutable();
@@ -48,24 +44,18 @@ class AuthController extends Controller
       ->withClaim('role', $user->role)
       ->getToken($this->config->signer(), $this->config->signingKey());
 
-    return $this->response->setJSON([
-      'success' => true,
-      'data' => [
-        'user' => [
-          'id' => $user->id,
-          'email' => $user->email,
-          'role' => $user->role,
-          'token' => $token->toString()
-        ]
+    return respondSuccess($this->response, [
+      'user' => [
+        'id' => $user->id,
+        'email' => $user->email,
+        'role' => $user->role,
+        'token' => $token->toString()
       ]
     ]);
   }
 
   public function logout()
   {
-    return $this->response->setJSON([
-      'success' => true,
-      'message' => 'Logout successful. Please remove token from client storage.'
-    ]);
+    return respondSuccess($this->response, null, 'Logout successful. Please remove token from client storage.');
   }
 }

--- a/app/Controllers/BarangController.php
+++ b/app/Controllers/BarangController.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Controllers;
+
+use Config\Database;
+use DateTime;
+
+class BarangController extends BaseController
+{
+  protected $db;
+
+  public function __construct()
+  {
+    $this->db = Database::connect();
+  }
+
+  /**
+   * GET /barang
+   * Get all items
+   */
+  public function index()
+  {
+    $items = $this->db->table('barang')->get()->getResult();
+
+    return respondSuccess($this->response, $items);
+  }
+
+  /**
+   * POST /barang
+   * Create item
+   */
+  public function create()
+  {
+    $data = $this->request->getJSON(true);
+
+    $now = (new DateTime())->format('Y-m-d H:i:s');
+
+    $insert = [
+      'kode'       => $data['kode'] ?? null,
+      'nama'       => $data['nama'] ?? null,
+      'kategori'   => $data['kategori'] ?? null,
+      'satuan'     => $data['satuan'] ?? null,
+      'harga'      => $data['harga'] ?? 0,
+      'supplier'   => $data['supplier'] ?? null,
+      'stokMinimal'=> $data['stokMinimal'] ?? 0,
+      'deskripsi'  => $data['deskripsi'] ?? null,
+      'createdAt'  => $now,
+      'updatedAt'  => $now,
+    ];
+
+    $this->db->table('barang')->insert($insert);
+    $id = $this->db->insertID();
+
+    $item = $this->db->table('barang')->where('id', $id)->get()->getRow();
+
+    return respondSuccess($this->response, $item, null, 201);
+  }
+
+  /**
+   * PUT /barang/{id}
+   * Update item
+   */
+  public function update($id)
+  {
+    $data = $this->request->getJSON(true);
+
+    $update = [];
+    if (array_key_exists('kode', $data)) $update['kode'] = $data['kode'];
+    if (array_key_exists('nama', $data)) $update['nama'] = $data['nama'];
+    if (array_key_exists('kategori', $data)) $update['kategori'] = $data['kategori'];
+    if (array_key_exists('satuan', $data)) $update['satuan'] = $data['satuan'];
+    if (array_key_exists('harga', $data)) $update['harga'] = $data['harga'];
+    if (array_key_exists('supplier', $data)) $update['supplier'] = $data['supplier'];
+    if (array_key_exists('stokMinimal', $data)) $update['stokMinimal'] = $data['stokMinimal'];
+    if (array_key_exists('deskripsi', $data)) $update['deskripsi'] = $data['deskripsi'];
+
+    $update['updatedAt'] = (new DateTime())->format('Y-m-d H:i:s');
+
+    $this->db->table('barang')->where('id', $id)->update($update);
+
+    $item = $this->db->table('barang')->where('id', $id)->get()->getRow();
+
+    return respondSuccess($this->response, $item);
+  }
+
+  /**
+   * DELETE /barang/{id}
+   * Delete item
+   */
+  public function delete($id)
+  {
+    $this->db->table('barang')->where('id', $id)->delete();
+
+    return respondSuccess($this->response, null, 'Item deleted successfully');
+  }
+}

--- a/app/Controllers/BaseController.php
+++ b/app/Controllers/BaseController.php
@@ -35,7 +35,7 @@ abstract class BaseController extends Controller
      *
      * @var list<string>
      */
-    protected $helpers = [];
+    protected $helpers = ['response'];
 
     /**
      * Be sure to declare properties for any property fetch you initialized.

--- a/app/Controllers/CompanyController.php
+++ b/app/Controllers/CompanyController.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace App\Controllers;
+
+use Config\Database;
+use DateTime;
+
+class CompanyController extends BaseController
+{
+    protected $db;
+
+    public function __construct()
+    {
+        $this->db = Database::connect();
+    }
+
+    /**
+     * GET /company
+     * Retrieve company settings record.
+     */
+    public function index()
+    {
+        $company = $this->db->table('company_settings')->get()->getRowArray();
+
+        $company = $company ? $this->formatCompany($company) : $this->defaultCompany();
+
+        return respondSuccess($this->response, $company);
+    }
+
+    /**
+     * PUT /company
+     * Update existing company settings or create a new one when missing.
+     */
+    public function update()
+    {
+        $payload = $this->request->getJSON(true) ?? [];
+        $fields  = ['name', 'address', 'phone', 'email', 'logo', 'settings'];
+        $update  = [];
+
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $payload)) {
+                $update[$field] = $payload[$field];
+            }
+        }
+
+        if (array_key_exists('settings', $update)) {
+            $settings = $update['settings'];
+            if (is_array($settings) || is_object($settings)) {
+                $update['settings'] = json_encode($settings);
+            }
+        }
+
+        if (empty($update)) {
+            $company = $this->db->table('company_settings')->get()->getRowArray();
+
+            return respondSuccess(
+                $this->response,
+                $company ? $this->formatCompany($company) : $this->defaultCompany()
+            );
+        }
+
+        $now     = (new DateTime())->format('Y-m-d H:i:s');
+        $table   = $this->db->table('company_settings');
+        $current = $table->get()->getRowArray();
+
+        $update['updatedAt'] = $now;
+
+        if ($current) {
+            $table->where('id', $current['id'])->update($update);
+            $id = $current['id'];
+        } else {
+            $update['createdAt'] = $now;
+            $table->insert($update);
+            $id = $this->db->insertID();
+        }
+
+        $company = $table->where('id', $id)->get()->getRowArray();
+
+        return respondSuccess(
+            $this->response,
+            $company ? $this->formatCompany($company) : $this->defaultCompany()
+        );
+    }
+
+    private function formatCompany(array $company): array
+    {
+        if (isset($company['settings'])) {
+            $settings = $company['settings'];
+            if (is_string($settings)) {
+                $decoded = json_decode($settings, true);
+                if (json_last_error() === JSON_ERROR_NONE) {
+                    $settings = $decoded;
+                }
+            }
+
+            if ($settings === null) {
+                $settings = [];
+            }
+
+            if ($settings instanceof \stdClass) {
+                $settings = (array) $settings;
+            }
+
+            if (! is_array($settings)) {
+                $settings = [];
+            }
+
+            $company['settings'] = empty($settings) ? new \stdClass() : $settings;
+        } else {
+            $company['settings'] = new \stdClass();
+        }
+
+        return $this->filterCompanyFields($company);
+    }
+
+    private function defaultCompany(): array
+    {
+        return [
+            'name'     => null,
+            'address'  => null,
+            'phone'    => null,
+            'email'    => null,
+            'logo'     => null,
+            'settings' => new \stdClass(),
+        ];
+    }
+
+    private function filterCompanyFields(array $company): array
+    {
+        $allowed = ['name', 'address', 'phone', 'email', 'logo', 'settings'];
+
+        $filtered = [];
+        foreach ($allowed as $field) {
+            if (array_key_exists($field, $company)) {
+                $filtered[$field] = $company[$field];
+            } else {
+                $filtered[$field] = $field === 'settings' ? new \stdClass() : null;
+            }
+        }
+
+        return $filtered;
+    }
+}

--- a/app/Controllers/DeliveryController.php
+++ b/app/Controllers/DeliveryController.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace App\Controllers;
+
+use Config\Database;
+use DateTime;
+
+class DeliveryController extends BaseController
+{
+    protected $db;
+
+    public function __construct()
+    {
+        $this->db = Database::connect();
+    }
+
+    /**
+     * GET /pengiriman
+     * Retrieve all deliveries with their items.
+     */
+    public function index()
+    {
+        $deliveries = $this->db->table('pengiriman')->get()->getResultArray();
+
+        foreach ($deliveries as &$delivery) {
+            $items = $this->db->table('pengiriman_items')
+                ->where('pengirimanId', $delivery['id'])
+                ->get()
+                ->getResultArray();
+
+            $delivery['items'] = $items;
+        }
+
+        return respondSuccess($this->response, $deliveries);
+    }
+
+    /**
+     * POST /pengiriman
+     * Create a new delivery with its items.
+     */
+    public function create()
+    {
+        $data = $this->request->getJSON(true) ?? [];
+        $now  = (new DateTime())->format('Y-m-d H:i:s');
+
+        $insert = [
+            'permintaanId'    => $data['permintaanId'] ?? null,
+            'nomorPengiriman' => $data['nomorPengiriman'] ?? null,
+            'tanggalKirim'    => $data['tanggalKirim'] ?? null,
+            'penerima'        => $data['penerima'] ?? null,
+            'alamatTujuan'    => $data['alamatTujuan'] ?? null,
+            'kurir'           => $data['kurir'] ?? null,
+            'status'          => $data['status'] ?? 'preparing',
+            'catatan'         => $data['catatan'] ?? null,
+            'createdAt'       => $now,
+            'updatedAt'       => $now,
+        ];
+
+        $this->db->table('pengiriman')->insert($insert);
+        $deliveryId = $this->db->insertID();
+
+        $items = $data['items'] ?? [];
+        foreach ($items as $item) {
+            $itemInsert = [
+                'pengirimanId' => $deliveryId,
+                'barangId'     => $item['barangId'] ?? null,
+                'quantity'     => $item['quantity'] ?? 0,
+                'satuan'       => $item['satuan'] ?? null,
+                'kondisi'      => $item['kondisi'] ?? null,
+                'createdAt'    => $now,
+                'updatedAt'    => $now,
+            ];
+
+            $this->db->table('pengiriman_items')->insert($itemInsert);
+        }
+
+        $created = $this->db->table('pengiriman')
+            ->where('id', $deliveryId)
+            ->get()
+            ->getRowArray();
+
+        if ($created) {
+            $created['items'] = $this->db->table('pengiriman_items')
+                ->where('pengirimanId', $deliveryId)
+                ->get()
+                ->getResultArray();
+        }
+
+        return respondSuccess($this->response, $created, null, 201);
+    }
+
+    /**
+     * PUT /pengiriman/{id}
+     * Update delivery details and optionally replace items.
+     */
+    public function update($id)
+    {
+        $data = $this->request->getJSON(true) ?? [];
+        $now  = (new DateTime())->format('Y-m-d H:i:s');
+
+        $update = [];
+        $fields = [
+            'permintaanId',
+            'nomorPengiriman',
+            'tanggalKirim',
+            'penerima',
+            'alamatTujuan',
+            'kurir',
+            'status',
+            'catatan',
+        ];
+
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $data)) {
+                $update[$field] = $data[$field];
+            }
+        }
+
+        if (! empty($update)) {
+            $update['updatedAt'] = $now;
+            $this->db->table('pengiriman')->where('id', $id)->update($update);
+        }
+
+        if (array_key_exists('items', $data) && is_array($data['items'])) {
+            $this->db->table('pengiriman_items')->where('pengirimanId', $id)->delete();
+
+            foreach ($data['items'] as $item) {
+                $itemInsert = [
+                    'pengirimanId' => $id,
+                    'barangId'     => $item['barangId'] ?? null,
+                    'quantity'     => $item['quantity'] ?? 0,
+                    'satuan'       => $item['satuan'] ?? null,
+                    'kondisi'      => $item['kondisi'] ?? null,
+                    'createdAt'    => $now,
+                    'updatedAt'    => $now,
+                ];
+
+                $this->db->table('pengiriman_items')->insert($itemInsert);
+            }
+        }
+
+        $delivery = $this->db->table('pengiriman')
+            ->where('id', $id)
+            ->get()
+            ->getRowArray();
+
+        if ($delivery) {
+            $delivery['items'] = $this->db->table('pengiriman_items')
+                ->where('pengirimanId', $id)
+                ->get()
+                ->getResultArray();
+        }
+
+        return respondSuccess($this->response, $delivery);
+    }
+}

--- a/app/Controllers/PermintaanController.php
+++ b/app/Controllers/PermintaanController.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Controllers;
+
+use Config\Database;
+use DateTime;
+
+class PermintaanController extends BaseController
+{
+    protected $db;
+
+    public function __construct()
+    {
+        $this->db = Database::connect();
+    }
+
+    /**
+     * GET /permintaan
+     * Retrieve all requests with their items.
+     */
+    public function index()
+    {
+        $requests = $this->db->table('permintaan')->get()->getResultArray();
+
+        foreach ($requests as &$request) {
+            $items = $this->db->table('permintaan_items')
+                ->where('permintaanId', $request['id'])
+                ->get()
+                ->getResultArray();
+
+            $request['items'] = $items;
+        }
+
+        return respondSuccess($this->response, $requests);
+    }
+
+    /**
+     * POST /permintaan
+     * Create a new request and related items.
+     */
+    public function create()
+    {
+        $data = $this->request->getJSON(true) ?? [];
+        $now  = (new DateTime())->format('Y-m-d H:i:s');
+
+        $insert = [
+            'nomorPermintaan' => $data['nomorPermintaan'] ?? null,
+            'tanggal'         => $data['tanggal'] ?? null,
+            'peminta'         => $data['peminta'] ?? null,
+            'prioritas'       => $data['prioritas'] ?? null,
+            'status'          => $data['status'] ?? 'pending',
+            'catatan'         => $data['catatan'] ?? null,
+            'createdAt'       => $now,
+            'updatedAt'       => $now,
+        ];
+
+        $this->db->table('permintaan')->insert($insert);
+        $permintaanId = $this->db->insertID();
+
+        $items = $data['items'] ?? [];
+        foreach ($items as $item) {
+            $itemInsert = [
+                'permintaanId' => $permintaanId,
+                'barangId'     => $item['barangId'] ?? null,
+                'quantity'     => $item['quantity'] ?? 0,
+                'satuan'       => $item['satuan'] ?? null,
+                'keterangan'   => $item['keterangan'] ?? null,
+                'createdAt'    => $now,
+                'updatedAt'    => $now,
+            ];
+
+            $this->db->table('permintaan_items')->insert($itemInsert);
+        }
+
+        $created = $this->db->table('permintaan')
+            ->where('id', $permintaanId)
+            ->get()
+            ->getRowArray();
+
+        $created['items'] = $this->db->table('permintaan_items')
+            ->where('permintaanId', $permintaanId)
+            ->get()
+            ->getResultArray();
+
+        return respondSuccess($this->response, $created, null, 201);
+    }
+
+    /**
+     * PUT /permintaan/{id}
+     * Update request details and optionally replace items.
+     */
+    public function update($id)
+    {
+        $data = $this->request->getJSON(true) ?? [];
+        $now  = (new DateTime())->format('Y-m-d H:i:s');
+
+        $update = [];
+        $fields = ['nomorPermintaan', 'tanggal', 'peminta', 'prioritas', 'status', 'catatan'];
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $data)) {
+                $update[$field] = $data[$field];
+            }
+        }
+
+        if (! empty($update)) {
+            $update['updatedAt'] = $now;
+            $this->db->table('permintaan')->where('id', $id)->update($update);
+        }
+
+        if (array_key_exists('items', $data) && is_array($data['items'])) {
+            $this->db->table('permintaan_items')->where('permintaanId', $id)->delete();
+
+            foreach ($data['items'] as $item) {
+                $itemInsert = [
+                    'permintaanId' => $id,
+                    'barangId'     => $item['barangId'] ?? null,
+                    'quantity'     => $item['quantity'] ?? 0,
+                    'satuan'       => $item['satuan'] ?? null,
+                    'keterangan'   => $item['keterangan'] ?? null,
+                    'createdAt'    => $now,
+                    'updatedAt'    => $now,
+                ];
+
+                $this->db->table('permintaan_items')->insert($itemInsert);
+            }
+        }
+
+        $request = $this->db->table('permintaan')
+            ->where('id', $id)
+            ->get()
+            ->getRowArray();
+
+        if ($request) {
+            $request['items'] = $this->db->table('permintaan_items')
+                ->where('permintaanId', $id)
+                ->get()
+                ->getResultArray();
+        }
+
+        return respondSuccess($this->response, $request);
+    }
+}

--- a/app/Controllers/ReportsController.php
+++ b/app/Controllers/ReportsController.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace App\Controllers;
+
+use Config\Database;
+use DateTime;
+
+class ReportsController extends BaseController
+{
+    protected $db;
+
+    public function __construct()
+    {
+        $this->db = Database::connect();
+    }
+
+    /**
+     * GET /laporan
+     * Retrieve all reports.
+     */
+    public function index()
+    {
+        $reports = $this->fetchReports();
+
+        return respondSuccess($this->response, $reports);
+    }
+
+    /**
+     * GET /laporan/penjualan
+     * Retrieve sales reports with optional date filters.
+     */
+    public function sales()
+    {
+        $reports = $this->fetchReports('penjualan');
+
+        return respondSuccess($this->response, $reports);
+    }
+
+    /**
+     * GET /laporan/permintaan
+     * Retrieve request reports with optional date filters.
+     */
+    public function requests()
+    {
+        $reports = $this->fetchReports('permintaan');
+
+        return respondSuccess($this->response, $reports);
+    }
+
+    /**
+     * GET /laporan/pengiriman
+     * Retrieve delivery reports with optional date filters.
+     */
+    public function deliveries()
+    {
+        $reports = $this->fetchReports('pengiriman');
+
+        return $this->response->setJSON([
+            'success' => true,
+            'data'    => $reports,
+        ]);
+    }
+
+    /**
+     * POST /laporan
+     * Create a new report entry.
+     */
+    public function create()
+    {
+        $data = $this->request->getJSON(true) ?? [];
+        $now  = (new DateTime())->format('Y-m-d H:i:s');
+
+        $insert = [
+            'judul'         => $data['judul'] ?? null,
+            'jenis'         => $data['jenis'] ?? null,
+            'pembuat'       => $data['pembuat'] ?? null,
+            'tanggalDibuat' => $data['tanggalDibuat'] ?? $now,
+            'status'        => $data['status'] ?? 'draft',
+            'data'          => isset($data['data']) ? json_encode($data['data']) : json_encode(new \stdClass()),
+            'createdAt'     => $now,
+        ];
+
+        $this->db->table('laporan')->insert($insert);
+        $reportId = $this->db->insertID();
+
+        $report = $this->db->table('laporan')
+            ->where('id', $reportId)
+            ->get()
+            ->getRowArray();
+
+        if ($report) {
+            $report['data'] = $this->decodeData($report['data'] ?? null);
+        }
+
+        return respondSuccess($this->response, $report, null, 201);
+    }
+
+    /**
+     * DELETE /laporan/{id}
+     * Remove a report entry.
+     */
+    public function delete($id)
+    {
+        $this->db->table('laporan')->where('id', $id)->delete();
+
+        return respondSuccess($this->response, null);
+    }
+
+    /**
+     * Fetch reports optionally filtered by type and date range.
+     */
+    protected function fetchReports(?string $type = null): array
+    {
+        $builder = $this->db->table('laporan');
+
+        if ($type !== null) {
+            $builder->where('jenis', $type);
+        }
+
+        $startDate = $this->request->getGet('startDate');
+        $endDate   = $this->request->getGet('endDate');
+
+        if (! empty($startDate)) {
+            $builder->where('tanggalDibuat >=', $startDate);
+        }
+
+        if (! empty($endDate)) {
+            $builder->where('tanggalDibuat <=', $endDate);
+        }
+
+        $reports = $builder->get()->getResultArray();
+
+        foreach ($reports as &$report) {
+            $report['data'] = $this->decodeData($report['data'] ?? null);
+        }
+
+        return $reports;
+    }
+
+    /**
+     * Safely decode report data JSON.
+     */
+    protected function decodeData(?string $payload)
+    {
+        if ($payload === null || $payload === '') {
+            return new \stdClass();
+        }
+
+        $decoded = json_decode($payload, true);
+
+        return $decoded === null ? new \stdClass() : $decoded;
+    }
+}

--- a/app/Controllers/StockController.php
+++ b/app/Controllers/StockController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Controllers;
+
+use Config\Database;
+use DateTime;
+
+class StockController extends BaseController
+{
+  protected $db;
+
+  public function __construct()
+  {
+    $this->db = Database::connect();
+  }
+
+  /**
+   * GET /stok
+   * Get stock information
+   */
+  public function index()
+  {
+    $barangId = $this->request->getGet('barangId');
+    $builder  = $this->db->table('stok');
+
+    if (!empty($barangId)) {
+      $builder->where('barangId', $barangId);
+    }
+
+    $stocks = $builder->get()->getResult();
+
+    return respondSuccess($this->response, $stocks);
+  }
+
+  /**
+   * PUT /stok
+   * Update stock
+   */
+  public function update()
+  {
+    $data = $this->request->getJSON(true);
+
+    $barangId = $data['barangId'] ?? null;
+    $quantity = (int) ($data['quantity'] ?? 0);
+    $type     = $data['type'] ?? 'add';
+
+    if (empty($barangId)) {
+      return respondBadRequest($this->response, 'barangId is required');
+    }
+
+    $builder = $this->db->table('stok');
+    $stock   = $builder->where('barangId', $barangId)->get()->getRowArray();
+
+    $now = (new DateTime())->format('Y-m-d H:i:s');
+
+    if ($stock) {
+      $currentQuantity = (int) ($stock['quantity'] ?? 0);
+
+      if ($type === 'subtract') {
+        $newQuantity = max(0, $currentQuantity - $quantity);
+      } else {
+        $newQuantity = $currentQuantity + $quantity;
+      }
+
+      $builder->where('barangId', $barangId)->update([
+        'quantity'    => $newQuantity,
+        'lastUpdated' => $now,
+      ]);
+    } else {
+      $newQuantity = $type === 'subtract' ? 0 : max(0, $quantity);
+
+      $builder->insert([
+        'barangId'    => $barangId,
+        'quantity'    => $newQuantity,
+        'lastUpdated' => $now,
+      ]);
+    }
+
+    $updatedStock = $builder->where('barangId', $barangId)->get()->getRow();
+
+    return respondSuccess($this->response, $updatedStock);
+  }
+}

--- a/app/Controllers/SupplierController.php
+++ b/app/Controllers/SupplierController.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Controllers;
+
+use Config\Database;
+use DateTime;
+
+class SupplierController extends BaseController
+{
+  protected $db;
+
+  public function __construct()
+  {
+    $this->db = Database::connect();
+  }
+
+  /**
+   * GET /supplier
+   * Get all suppliers
+   */
+  public function index()
+  {
+    $suppliers = $this->db->table('supplier')->get()->getResult();
+
+    return respondSuccess($this->response, $suppliers);
+  }
+
+  /**
+   * POST /supplier
+   * Create supplier
+   */
+  public function create()
+  {
+    $data = $this->request->getJSON(true);
+
+    $now = (new DateTime())->format('Y-m-d H:i:s');
+
+    $insert = [
+      'nama'      => $data['nama'] ?? null,
+      'kontak'    => $data['kontak'] ?? null,
+      'alamat'    => $data['alamat'] ?? null,
+      'email'     => $data['email'] ?? null,
+      'telepon'   => $data['telepon'] ?? null,
+      'status'    => 'active',
+      'createdAt' => $now,
+      'updatedAt' => $now,
+    ];
+
+    $this->db->table('supplier')->insert($insert);
+    $id = $this->db->insertID();
+
+    $supplier = $this->db->table('supplier')->where('id', $id)->get()->getRow();
+
+    return respondSuccess($this->response, $supplier, null, 201);
+  }
+
+  /**
+   * PUT /supplier/{id}
+   * Update supplier
+   */
+  public function update($id)
+  {
+    $data = $this->request->getJSON(true);
+
+    $update = [];
+    if (array_key_exists('nama', $data)) $update['nama'] = $data['nama'];
+    if (array_key_exists('kontak', $data)) $update['kontak'] = $data['kontak'];
+    if (array_key_exists('alamat', $data)) $update['alamat'] = $data['alamat'];
+    if (array_key_exists('email', $data)) $update['email'] = $data['email'];
+    if (array_key_exists('telepon', $data)) $update['telepon'] = $data['telepon'];
+    if (array_key_exists('status', $data)) $update['status'] = $data['status'];
+
+    $update['updatedAt'] = (new DateTime())->format('Y-m-d H:i:s');
+
+    $this->db->table('supplier')->where('id', $id)->update($update);
+
+    $supplier = $this->db->table('supplier')->where('id', $id)->get()->getRow();
+
+    return respondSuccess($this->response, $supplier);
+  }
+
+  /**
+   * DELETE /supplier/{id}
+   * Delete supplier
+   */
+  public function delete($id)
+  {
+    $this->db->table('supplier')->where('id', $id)->delete();
+
+    return respondSuccess($this->response, null, 'Supplier deleted successfully');
+  }
+}

--- a/app/Controllers/UserController.php
+++ b/app/Controllers/UserController.php
@@ -2,11 +2,10 @@
 
 namespace App\Controllers;
 
-use CodeIgniter\Controller;
 use Config\Database;
 use DateTime;
 
-class UserController extends Controller
+class UserController extends BaseController
 {
   protected $db;
 
@@ -23,10 +22,7 @@ class UserController extends Controller
   {
     $users = $this->db->table('users')->get()->getResult();
 
-    return $this->response->setJSON([
-      'success' => true,
-      'data'    => $users
-    ]);
+    return respondSuccess($this->response, $users);
   }
 
   /**
@@ -49,17 +45,14 @@ class UserController extends Controller
     $this->db->table('users')->insert($insert);
     $id = $this->db->insertID();
 
-    return $this->response->setJSON([
-      'success' => true,
-      'data'    => [
-        'id'        => $id,
-        'name'      => $insert['name'],
-        'email'     => $insert['email'],
-        'role'      => $insert['role'],
-        'status'    => $insert['status'],
-        'createdAt' => $insert['createdAt']
-      ]
-    ]);
+    return respondSuccess($this->response, [
+      'id'        => $id,
+      'name'      => $insert['name'],
+      'email'     => $insert['email'],
+      'role'      => $insert['role'],
+      'status'    => $insert['status'],
+      'createdAt' => $insert['createdAt']
+    ], null, 201);
   }
 
   /**
@@ -82,10 +75,7 @@ class UserController extends Controller
 
     $user = $this->db->table('users')->where('id', $id)->get()->getRow();
 
-    return $this->response->setJSON([
-      'success' => true,
-      'data'    => $user
-    ]);
+    return respondSuccess($this->response, $user);
   }
 
   /**
@@ -96,9 +86,6 @@ class UserController extends Controller
   {
     $this->db->table('users')->where('id', $id)->delete();
 
-    return $this->response->setJSON([
-      'success' => true,
-      'message' => 'User deleted successfully'
-    ]);
+    return respondSuccess($this->response, null, 'User deleted successfully');
   }
 }

--- a/app/Helpers/response_helper.php
+++ b/app/Helpers/response_helper.php
@@ -1,0 +1,81 @@
+<?php
+
+use CodeIgniter\HTTP\ResponseInterface;
+
+if (! function_exists('respondSuccess')) {
+    /**
+     * Return a standardized success response payload.
+     */
+    function respondSuccess(
+        ResponseInterface $response,
+        $data = null,
+        ?string $message = null,
+        int $statusCode = 200
+    ): ResponseInterface {
+        $payload = ['success' => true];
+
+        if (func_num_args() >= 2) {
+            $payload['data'] = $data;
+        }
+
+        if ($message !== null) {
+            $payload['message'] = $message;
+        }
+
+        return $response->setStatusCode($statusCode)->setJSON($payload);
+    }
+}
+
+if (! function_exists('respondError')) {
+    /**
+     * Return a standardized error response payload.
+     */
+    function respondError(
+        ResponseInterface $response,
+        string $message,
+        string $error,
+        int $statusCode
+    ): ResponseInterface {
+        return $response->setStatusCode($statusCode)->setJSON([
+            'success' => false,
+            'error'   => $error,
+            'message' => $message,
+        ]);
+    }
+}
+
+if (! function_exists('respondBadRequest')) {
+    function respondBadRequest(ResponseInterface $response, string $message = 'Validation error description'): ResponseInterface
+    {
+        return respondError($response, $message, 'Bad Request', 400);
+    }
+}
+
+if (! function_exists('respondUnauthorized')) {
+    function respondUnauthorized(ResponseInterface $response, string $message = 'JWT token is required or invalid'): ResponseInterface
+    {
+        return respondError($response, $message, 'Unauthorized', 401);
+    }
+}
+
+if (! function_exists('respondForbidden')) {
+    function respondForbidden(ResponseInterface $response, string $message = 'Insufficient permissions'): ResponseInterface
+    {
+        return respondError($response, $message, 'Forbidden', 403);
+    }
+}
+
+if (! function_exists('respondNotFound')) {
+    function respondNotFound(ResponseInterface $response, string $message = 'Resource not found'): ResponseInterface
+    {
+        return respondError($response, $message, 'Not Found', 404);
+    }
+}
+
+if (! function_exists('respondServerError')) {
+    function respondServerError(ResponseInterface $response, string $message = 'An unexpected error occurred'): ResponseInterface
+    {
+        return respondError($response, $message, 'Internal Server Error', 500);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a reusable response helper to centralize success and error payload shapes
- load the new helper for all controllers and refactor API endpoints to call the shared response builders

## Testing
- composer test *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d367eaa56083328707ec1040f32194